### PR TITLE
Fix intDiv for bigints by not using floats

### DIFF
--- a/src/Data/EuclideanRing.erl
+++ b/src/Data/EuclideanRing.erl
@@ -1,20 +1,11 @@
 -module(data_euclideanRing@foreign).
 -export([intDegree/1, intDiv/2, intMod/2, numDiv/2]).
 
-intDegree(X) -> abs(X).
+intDegree(X) -> erlang:abs(X).
 
 intDiv(_, 0) -> 0;
-intDiv(X, Y) when Y > 0 -> floor_(X / Y);
-intDiv(X, Y) -> -floor_(X / -Y).
-
-% Not supported natively until erlang 20
-floor_(X) ->
-    T = erlang:trunc(X),
-    case (X - T) of
-        Neg when Neg < 0 -> T - 1;
-        Pos when Pos > 0 -> T;
-        _ -> T
-    end.
+intDiv(X, Y) when X < 0 -> (X - erlang:abs(Y) + 1) div (Y);
+intDiv(X, Y) -> X div Y.
 
 intMod(_, 0) -> 0;
 intMod(X, Y) -> 


### PR DESCRIPTION
I tested that this agrees with behavior of the JS Prelude for negative integers

unfortunately both purerl and purescript-backend-erl will optimize to regular Erlang `div` (in different scenarios, since backend-erl does optimizations), so the correctness of this FFI implementation ends up not mattering much

(how I found the bigint bug was by disabling the optimization)

Proof that this works for bigints:

```erlang
3> 80126697530880000000000 / 55319040000000000.
1448446.9999999998
4> intDiv(80126697530880000000000, 55319040000000000).
1448447
```